### PR TITLE
Do not concatenate file paths

### DIFF
--- a/src/LicenseHeader.php
+++ b/src/LicenseHeader.php
@@ -77,9 +77,9 @@ class LicenseHeader
             $fromSrcFolderFilePath = __DIR__ . '/../' . $this->filePath;
 
             if (\file_exists($fromRelativeFilePath)) {
-                $this->filePath = $fromRelativeFilePath . $this->filePath;
+                $this->filePath = $fromRelativeFilePath;
             } elseif (\file_exists($fromSrcFolderFilePath)) {
-                $this->filePath = $fromSrcFolderFilePath . $this->filePath;
+                $this->filePath = $fromSrcFolderFilePath;
             } else {
                 throw new \Exception(
                     'File ' . $this->filePath . ' does not exist.'


### PR DESCRIPTION
Fixes 

```$ vendor/bin/pimp-my-header --license=assets/afl.txt

In LicenseHeader.php line 91:
                                                                                                                                       
  File /home/thomas/Documents/github/ps_checkout/vendor/prestashop/pimp-my-header/src/../assets/afl.txtassets/afl.txt cannot be read.  
                                                                                                                                       

prestashop:licenses:update [--license LICENSE] [--exclude EXCLUDE] [--extensions EXTENSIONS]
```
